### PR TITLE
Changed link for extended flag

### DIFF
--- a/src/test/groovy/org/groovykoans/koan07/Koan07.groovy
+++ b/src/test/groovy/org/groovykoans/koan07/Koan07.groovy
@@ -18,7 +18,7 @@ import java.util.regex.Pattern
  *   * http://docs.groovy-lang.org/latest/html/documentation/index.html#all-strings
  *   * http://docs.groovy-lang.org/latest/html/documentation/index.html#_regular_expression_operators
  *   * http://naleid.com/blog/2009/04/07/groovy-161-released-with-new-find-and-findall-regexp-methods-on-string/
- *   * http://www.groovy-lang.org/operators.html#_regular_expression_operators
+ *   * http://www.ngdc.noaa.gov/wiki/index.php/Regular_Expressions_in_Groovy#The_eXtended_Pattern_Match_Flag_.28x.29
  */
 class Koan07 extends GroovyTestCase {
 

--- a/src/test/groovy/org/groovykoans/koan07/Koan07.groovy
+++ b/src/test/groovy/org/groovykoans/koan07/Koan07.groovy
@@ -160,7 +160,7 @@ and can become difficult to maintain"""
     void test06_MultilineRegexWithComments() {
         // Regular expression can become lengthy and hard to read. Groovy solves this by adding a special
         // "extended" (x) flag that ignores newlines and spaces. Read about it here:
-        // http://www.groovy-lang.org/operators.html#_regular_expression_operators
+        // http://www.ngdc.noaa.gov/wiki/index.php/Regular_Expressions_in_Groovy#The_eXtended_Pattern_Match_Flag_.28x.29
 
         // Let's take the text from the exercise above:
         def text = '''|Item          # Sold  Leftover

--- a/src/test/groovy/org/groovykoans/koan09/Koan09.groovy
+++ b/src/test/groovy/org/groovykoans/koan09/Koan09.groovy
@@ -15,7 +15,7 @@ package org.groovykoans.koan09
  *   * http://mrhaki.blogspot.com/2009/11/groovy-goodness-intercept-methods-with.html
  *   * http://docs.groovy-lang.org/latest/html/documentation/index.html#_closures
  *   * http://stackoverflow.com/questions/8120949/what-does-delegate-mean-in-groovy/8121750#8121750
- *   * http://docs.groovy-lang.org/latest/html/documentation/index.html#_expando
+ *   * http://docs.groovy-lang.org/latest/html/documentation/index.html#_invokemethod
  *   * http://mrhaki.blogspot.com/2009/12/groovy-goodness-adding-or-overriding.html
  *   * http://www.codinghorror.com/blog/2007/02/why-cant-programmers-program.html,
  *
@@ -138,7 +138,7 @@ class Koan09 extends GroovyTestCase {
         assert robot.y == -1
 
         // Wouldn't it be nicer if we could create shorthand versions for combo moves? For example, goLeftLeftRightDown()?
-        // Read about invokeMethod() here: http://docs.groovy-lang.org/latest/html/documentation/index.html#_expando
+        // Read about invokeMethod() here: http://docs.groovy-lang.org/latest/html/documentation/index.html#_invokemethod
         // invokeMethod() allows you to intercept all method calls, even if the method doesn't exist.
 
         // Using invokeMethod(), handle every possible goXYZ combination... Regular expressions will come in handy.


### PR DESCRIPTION
The old link does not seem to mention anything about the extended flag. The page probably got changed over time. The best alternative link I could find was this one: http://www.ngdc.noaa.gov/wiki/index.php/Regular_Expressions_in_Groovy#The_eXtended_Pattern_Match_Flag_.28x.29